### PR TITLE
Add host pattern-based interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The tool starts a proxy server and then runs the specified command with appropri
 - `--return-code N, -r N`: Return status code N for all requests
 - `--return-header H`: Add header H to responses (can repeat)
 - `--return-data DATA`: Return DATA as response body
+- `--intercept-pattern PATTERN`: Only intercept requests to hosts matching PATTERN (can repeat)
 
 ### Examples
 
@@ -83,6 +84,15 @@ Return custom response with headers and body:
 Use specific port instead of auto-selection:
 ```bash
 ./proxyspy.py --port 8888 -- curl https://httpbin.org/ip
+```
+
+Intercept only requests to specific domains:
+```bash
+./proxyspy.py --return-code 404 \
+              --intercept-pattern "anaconda.org" \
+              --intercept-pattern "conda.io" \
+              -- python conda_script.py
+>>>>>>> 7b97ab6 (intercept only hosts that match one or more patterns)
 ```
 
 ## How It Works


### PR DESCRIPTION
_This code, README modification, and PR text was written by Claude 3.7, based on a recommendation it suggested after analyzing the current state of the code_

This PR adds the ability to selectively intercept requests based on host patterns. This feature is particularly useful when working with applications that make requests to multiple domains, but you only want to intercept specific ones.

## New Functionality

Adds a new --intercept-pattern command-line option that can be specified multiple times
When patterns are provided, only requests to hosts containing any of the patterns will be intercepted
All other requests will be forwarded normally, even when interception options are enabled

## Implementation

- Simple substring matching against the target hostname:port
- Clear logging about which patterns matched/didn't match
- Comprehensive test coverage for both matching and non-matching scenarios

## Use Case

This is particularly valuable for applications that interact with package repositories (like conda) where you might want to monitor or modify requests to specific domains while allowing other traffic to flow normally.

## Example

```
./proxyspy.py --return-code 404 \
              --return-data '{"error": "Not found"}' \
              --intercept-pattern "anaconda.org" \
              -- conda install package
```