### PR TITLE
auto-select port by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A debugging proxy that can log or intercept HTTPS requests. This tool can be use
 - Connection delays for testing
 - Concurrent connection support
 - Binary data handling
+- Automatic port selection
 
 ## Installation
 
@@ -52,7 +53,7 @@ The tool starts a proxy server and then runs the specified command with appropri
 ### Options
 
 - `--logfile FILE, -l FILE`: Write logs to FILE (default: stdout)
-- `--port PORT, -p PORT`: Listen on PORT (default: 8080)
+- `--port PORT, -p PORT`: Listen on PORT (default: auto-select)
 - `--keep-certs`: Keep certificates in current directory
 - `--delay TIME`: Add TIME seconds delay to each connection
 - `--return-code N, -r N`: Return status code N for all requests
@@ -79,6 +80,11 @@ Return custom response with headers and body:
               -- ./my_script.py
 ```
 
+Use specific port instead of auto-selection:
+```bash
+./proxyspy.py --port 8888 -- curl https://httpbin.org/ip
+```
+
 ## How It Works
 
 The proxy operates in two modes and can optionally add delays to any connection:
@@ -98,6 +104,11 @@ The proxy operates in two modes and can optionally add delays to any connection:
 - Delay occurs after connection but before SSL handshake
 - Useful for testing timeout and connection handling
 
+### Port Selection
+- By default, the proxy automatically selects an available port
+- This prevents socket reuse issues and allows running multiple instances
+- A specific port can be chosen with the --port option
+
 ## Development
 
 Run tests:
@@ -111,6 +122,7 @@ The test suite covers:
 - Binary data handling
 - Connection delays
 - Error conditions
+- Sequential proxy starts
 
 ## Contributing
 
@@ -124,4 +136,4 @@ When submitting pull requests, please:
 
 ## About This Project
 
-This project was primarily developed through a series of conversations with Claude 3.5 Sonnet, an AI assistant from Anthropic (https://claude.ai). The majority of the code, including the test suite and GitHub Actions configuration, was written by Claude in response to requirements and refinements from human developers. This collaborative approach demonstrates how AI assistance can help create well-tested, maintainable code while adhering to strict dependency and design constraints.
+This project was primarily developed through a series of conversations with Claude 3.5 and 3.7 Sonnet, an AI assistant from Anthropic (https://claude.ai). The majority of the code, including the test suite and GitHub Actions configuration, was written by Claude in response to requirements and refinements from human developers. This collaborative approach demonstrates how AI assistance can help create well-tested, maintainable code while adhering to strict dependency and design constraints.

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "proxyspy" %}
-{% set version = "0.1.0.post5" %}
+{% set version = "0.1.1.post4" %}
 
 package:
   name: {{ name }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "proxyspy"
-version = "0.1.0.post5"
+version = "0.1.1.post4"
 description = "A debugging proxy that can log or intercept HTTPS requests"
 readme = "README.md"
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
[code and PR courtesy Claude 3.7]

# Add Automatic Port Selection

## Problem

The proxy was consistently experiencing "Broken pipe" socket errors on ARM-based Ubuntu workers, but not on other platforms (Intel Linux, macOS, or Windows). Investigation revealed that this issue was likely due to socket TIME_WAIT states not being properly handled when reusing the same port in quick succession. Different operating systems and architectures handle socket cleanup differently, with ARM Linux appearing to be more strict about socket reuse.

## Solution

This PR implements automatic port selection to avoid socket reuse issues:

1. Changed the default port behavior from a fixed port (8080) to auto-selection
2. Modified the `main()` function to automatically find an available port when port 0 is specified
3. Added a new test that verifies sequential proxy starts work correctly
4. Updated documentation to reflect the new auto-port selection feature

The solution prevents socket binding errors by rotating ports between runs, ensuring that we never try to reuse a port that might be in TIME_WAIT state.

## Testing

Added a new test case `test_sequential_proxy_starts` that:
- Starts the proxy multiple times in sequence
- Verifies that auto-port selection works correctly
- Confirms that different ports are selected across runs
- Makes test requests to ensure the proxy functions properly

This test now passes consistently on all platforms, including ARM Linux.

## Documentation

- Updated README.md to document the auto-port selection feature
- Added an example of how to specify a fixed port
- Added "Port Selection" section to the "How It Works" part of the documentation

## Notes for Reviewers

- The default behavior has changed from using port 8080 to auto-selecting a port
- This should be more robust in CI environments and when running multiple tests in parallel
- Users can still specify a fixed port with the `--port` option if needed