### PR TITLE
add pre-computation of SSL certs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -113,7 +113,7 @@ jobs:
     - name: Example output for timing study
       run: |
         conda activate testconda
-        proxyspy --debug conda search --override-channels -c conda-forge proxyspy
+        proxyspy --debug -- python -c 'import urllib.request; urllib.request.urlopen("https://httpbin.org")'
 
   publish:
     needs: test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -110,6 +110,11 @@ jobs:
         pip install "${wheel_file}[test]"
         pytest -v tests || pytest -v tests
 
+    - name: Example output for timing study
+      run: |
+        conda activate testconda
+        proxyspy --debug conda search --override-channels -c conda-forge proxyspy
+
   publish:
     needs: test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The tool starts a proxy server and then runs the specified command with appropri
 - `--return-code N, -r N`: Return status code N for all requests
 - `--return-header H`: Add header H to responses (can repeat)
 - `--return-data DATA`: Return DATA as response body
-- `--intercept-pattern PATTERN`: Only intercept requests to hosts matching PATTERN (can repeat)
+- `--intercept-host HOST`: Only intercept requests to HOST (can repeat)
 
 ### Examples
 
@@ -89,8 +89,8 @@ Use specific port instead of auto-selection:
 Intercept only requests to specific domains:
 ```bash
 ./proxyspy.py --return-code 404 \
-              --intercept-pattern "anaconda.org" \
-              --intercept-pattern "conda.io" \
+              --intercept-host "conda.anaconda.org" \
+              --intercept-host "repo.anaconda.com" \
               -- python conda_script.py
 ```
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "proxyspy" %}
-{% set version = "0.1.1.post4" %}
+{% set version = "0.1.2.post3" %}
 
 package:
   name: {{ name }}

--- a/proxyspy.py
+++ b/proxyspy.py
@@ -88,6 +88,7 @@ def read_or_create_cert(host=None):
     global CA_KEY
 
     is_CA = host is None
+    logger.debug("Certificate requested for %s", host or "<CA>")
 
     assert CERT_DIR
     cert_path = join(CERT_DIR, "cert.pem" if is_CA else "%s-cert.pem" % host)
@@ -123,6 +124,7 @@ def read_or_create_cert(host=None):
         public_exponent=65537,
         key_size=2048,
     )
+    logger.debug("Private key generated")
     pub = key.public_key()
     if not host:
         CA_KEY = key
@@ -157,9 +159,11 @@ def read_or_create_cert(host=None):
         )
     else:
         cert = cert.add_extension(x509.SubjectAlternativeName([x509.DNSName(host)]), critical=False)
+    logger.debug("Certificate constructed")
 
     # Sign with CA key
     cert = cert.sign(CA_KEY, hashes.SHA256())
+    logger.debug("Certificate signed")
     if is_CA:
         CA_CERT = cert
 
@@ -176,6 +180,7 @@ def read_or_create_cert(host=None):
         f.write(key_pem)
     with open(cert_path, "wb") as f:
         f.write(cert_pem)
+    logger.debug("Certificates written to disk")
 
     return cert_path, key_path
 
@@ -198,7 +203,7 @@ class MyHTTPServer(ThreadingHTTPServer):
         self.lock = Lock()
         # Interception settings
         self.intercept_mode = False
-        self.intercept_patterns = []
+        self.intercept_hosts = []
         self.return_code = 200  # Default if in intercept mode
         self.return_headers = []  # List of (name, value) tuples
         self.return_data = ""  # Response body
@@ -307,15 +312,12 @@ class ProxyHandler(BaseHTTPRequestHandler):
             self._log("[C<>P] SSL handshake completed")
 
             should_intercept = self.server.intercept_mode
-            if should_intercept and self.server.intercept_patterns:
-                should_intercept = False
-                for pattern in self.server.intercept_patterns:
-                    if pattern in host:  # Simple substring matching
-                        self._log("Host %s matches intercept pattern %s", host, pattern)
-                        should_intercept = True
-                        break
-                if not should_intercept:
-                    self._log("Host %s does not match any intercept patterns, forwarding", host)
+            if should_intercept and self.server.intercept_hosts:
+                should_intercept = host in self.server.intercept_hosts
+                if should_intercept:
+                    self._log("Host %s found in intercept list" % host)
+                else:
+                    self._log("Host %s not found in intercept list, forwarding" % host)
 
             if should_intercept:
                 # Read the decrypted request
@@ -471,9 +473,14 @@ def main():
         help="HTTP status code to return for all requests",
     )
     parser.add_argument(
-        "--intercept-pattern",
+        "--intercept-host",
         action="append",
-        help="Only intercept requests matching this pattern (e.g. 'conda.anaconda.org')",
+        help="Only intercept requests from this host (e.g. 'conda.anaconda.org') (can be repeated)",
+    )
+    parser.add_argument(
+        "--prepare-host",
+        action="append",
+        help="Prepare the SSL certificate for this host in advance, to reduce the first connection delay (can be repeated)"
     )
     parser.add_argument(
         "--return-header",
@@ -481,12 +488,13 @@ def main():
         help='Response header in format "Name: Value" (can be repeated)',
     )
     parser.add_argument("--return-data", help="Response body to return")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     parser.add_argument("command", nargs="+", help="Command to run and its arguments")
     args = parser.parse_args()
 
     # Configure logging
     logging_config = {
-        "level": logging.INFO,
+        "level": logging.DEBUG if args.debug else logging.INFO,
         "format": LOG_FORMAT,
         "handlers": [],
     }
@@ -512,6 +520,8 @@ def main():
         atexit.register(cleanup)
     logger.info("Certificate directory: %s", CERT_DIR)
     cert_path, key_path = read_or_create_cert()
+    for host in set(args.intercept_host) | set(args.prepare_host):
+        read_or_create_cert(host)
 
     # Start and configure server
     port = args.port
@@ -526,7 +536,7 @@ def main():
         server.intercept_mode = True
         server.return_code = args.return_code or 200
         server.return_data = args.return_data or ""
-        server.intercept_patterns = args.intercept_pattern or []
+        server.intercept_hosts = args.intercept_host or []
 
         # Parse headers
         server.return_headers = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "proxyspy"
-version = "0.1.1.post4"
+version = "0.1.2.post3"
 description = "A debugging proxy that can log or intercept HTTPS requests"
 readme = "README.md"
 license = { file = "LICENSE.txt" }

--- a/tests/test_proxyspy.py
+++ b/tests/test_proxyspy.py
@@ -364,6 +364,21 @@ def test_forwarding_response_body(proxy, session):
     assert len(response.content) == 1024
 
 
+def test_prepare_hosts(proxy):
+    proxy.start_proxy(
+        "--intercept-host",
+        "example.org",
+        "--intercept-host",
+        "example.com",
+        "--prepare-host",
+        "httpbin.org",
+        "--prepare-host",
+        "httpbin.com",
+    )
+    for host in ("example.org", "example.com", "httpbin.org", "httpbin.com"):
+        proxy.assert_log_contains("Requested certificate for " + host)
+
+
 def test_intercept_response_body(proxy, session):
     """Test that intercepted responses handle response bodies correctly."""
     # Create a response body with various challenging content
@@ -462,11 +477,16 @@ def test_intercept_headers(proxy, session):
 def test_intercept_hosts(proxy, session):
     """Test that the proxy only intercepts requests matching the specified patterns."""
     proxy.start_proxy(
-        "--return-code", "418",
-        "--return-header", "X-Test: Host Match",
-        "--return-data", '{"status": "intercepted by host list"}',
-        "--intercept-host", "httpbin.org",
-        "--intercept-host", "example.com"
+        "--return-code",
+        "418",
+        "--return-header",
+        "X-Test: Host Match",
+        "--return-data",
+        '{"status": "intercepted by host list"}',
+        "--intercept-host",
+        "httpbin.org",
+        "--intercept-host",
+        "example.com",
     )
 
     # Request 1: Should match first pattern
@@ -474,47 +494,47 @@ def test_intercept_hosts(proxy, session):
     assert resp_match1.status_code == 418
     proxy.verify_header(resp_match1, "X-Test", "Host Match")
     assert resp_match1.json() == {"status": "intercepted by host list"}
-    
+
     # Force refresh logs and verify first request
     proxy.get_logs(force=True)
     assert any("httpbin.org found in intercept list" in line for line in proxy.get_logs())
-    
+
     # Request 2: Should match second pattern
     resp_match2 = session.get("https://example.com/")
     assert resp_match2.status_code == 418
     proxy.verify_header(resp_match2, "X-Test", "Host Match")
     assert resp_match2.json() == {"status": "intercepted by host list"}
-    
+
     # Force refresh logs and verify second request
     proxy.get_logs(force=True)
     assert any("example.com found in intercept list" in line for line in proxy.get_logs())
-    
+
     # Request 3: Should not match any pattern
     resp_nomatch = session.get("https://example.org/")
     assert resp_nomatch.status_code == 200
     assert "Example Domain" in resp_nomatch.text
-    
+
     # Force refresh logs and verify third request
     logs = proxy.get_logs(force=True)
     assert any("example.org not found in intercept list" in line for line in logs)
-    
+
     # Check connections to verify SSL handshakes
     connections = proxy.get_connections()
-    
+
     # Helper function to check if a connection was intercepted or forwarded
     def find_connection(domain):
         for cid, lines in connections.items():
             if any(domain in line for line in lines):
                 return lines
         return None
-    
+
     # Verify both matching connections were intercepted (client SSL but no server SSL)
     for domain in ["httpbin.org", "example.com"]:
         conn_lines = find_connection(domain)
         assert conn_lines is not None, f"Connection for {domain} not found"
         assert any("[C<>P] SSL handshake completed" in line for line in conn_lines)
         assert not any("[P<>S] SSL handshake completed" in line for line in conn_lines)
-    
+
     # Verify non-matching connection was forwarded (both client and server SSL)
     nonmatch_lines = find_connection("example.org")
     assert nonmatch_lines is not None, "Connection for example.org not found"


### PR DESCRIPTION
If a client being tested expects a rapid response from the request host, the delay caused by the creation of the SSL certificate can be a problem. To resolve this, we have:

- Created a new, repeatable option `--prepare-host` that causes SSL certificates to be created for that host prior to the starting of the proxy server and underlying client.
- Simplified `--inspect-pattern` to `--inspect-host`, and given the same SSL certificate treatment to its arguments

We have also added `--debug` logging to better reveal the timing bottlenecks in certificate generation. Currently the SSL certificate code is the only place this is used.