### PR TITLE
Add AuthorityKeyIdentifier extension to non-CA cert

### DIFF
--- a/proxyspy.py
+++ b/proxyspy.py
@@ -159,7 +159,13 @@ def read_or_create_cert(host=None):
             critical=False,
         )
     else:
-        cert = cert.add_extension(x509.SubjectAlternativeName([x509.DNSName(host)]), critical=False)
+        cert = cert.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(host)]), 
+            critical=False
+        ).add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(CA_KEY.public_key()),
+            critical=False,
+        )
     logger.debug("Certificate constructed")
 
     # Sign with CA key


### PR DESCRIPTION
I was encountering errors of this form while using `proxyspy` with newer versions of `conda`:
```
Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')': /pkgs/main/linux-64/current_repodata.json.zst
```
This fix was suggested by claude to add the AuthorityKeyIdentifier extension.