### PR TITLE
Improve certificate extensions for Python 3.13 support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
```
SSL error: [SSL: SSLV3_ALERT_CERTIFICATE_UNKNOWN] sslv3 alert certificate unknown (_ssl.c:1032)
```
This is now happening with Python 3.13 on Linux and macOS platforms. When running:
```
proxyspy --return-code 404 -- conda install --override-channels -c defaults fakepackage
```

Claude has diagnosed this as a failure to include important extensions into the host certificates:

> 1. Missing KeyUsage extension for host certificates - The current code only adds KeyUsage to the CA cert, not host certs
> 2. Missing ExtendedKeyUsage extension - This explicitly marks the certificate for TLS server authentication, which Python 3.13 may require

This PR adds those.